### PR TITLE
feat: Ctrl+mousewheel zoom (bug 9)

### DIFF
--- a/main.js
+++ b/main.js
@@ -996,6 +996,12 @@ ipcMain.handle('dialog:truncate-file', async (event, filePath, size) => {
   }
 });
 
+ipcMain.handle('zoom-step', (_event, delta) => {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    applyZoom(mainWindow, _currentZoom + (delta > 0 ? 1 : -1));
+  }
+});
+
 function createWindow() {
   const buildMode = getBuildMode();
   setupMenu(buildMode);

--- a/src/support/preload.js
+++ b/src/support/preload.js
@@ -599,3 +599,10 @@ if (typeof window.chrome === 'undefined' || !window.chrome.fileSystem) {
         fileSystem: chromeFileSystem,
     });
 }
+
+// Ctrl+mousewheel zoom: intercept before Chromium's own fractional zoom kicks in
+window.addEventListener('wheel', function (event) {
+    if (!(event.ctrlKey || event.metaKey)) return;
+    event.preventDefault();
+    ipcRenderer.invoke('zoom-step', event.deltaY < 0 ? 1 : -1);
+}, { passive: false, capture: true });


### PR DESCRIPTION
## Summary
- Adds Ctrl+mousewheel zoom support (bug 9)
- `preload.js`: capture-phase `wheel` listener intercepts Ctrl+wheel, calls `event.preventDefault()` to block Chromium's own fractional zoom, then sends `ipcRenderer.invoke('zoom-step', ±1)` to main
- `main.js`: new `ipcMain.handle('zoom-step', ...)` handler calls `applyZoom()` — same path as keyboard Ctrl+/- shortcuts, so zoom uses consistent integer steps and respects the -9..+9 clamp

## Test plan
- [ ] `yarn dev` — hold Ctrl and scroll wheel up: zoom increases one step per notch
- [ ] Hold Ctrl and scroll wheel down: zoom decreases one step per notch
- [ ] Zoom stays clamped at -9 and +9 (no further change at limits)
- [ ] Ctrl+0 resets to default after wheeling
- [ ] Zoom persists across restart (same as keyboard zoom)
- [ ] Regular scroll (no Ctrl) still works normally (no zoom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added zoom functionality: Users can now zoom in and out using Ctrl+Scroll (Cmd+Scroll on macOS) to adjust the application's magnification level.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nerdCopter/EmuConfigurator_nerdRepo/pull/88)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->